### PR TITLE
Set flash cookie path to '/'

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -185,7 +185,10 @@ where
 
         if let Some(msg) = self.message {
             let data = serde_json::to_string(&msg.into_inner())?;
-            let flash_cookie = Cookie::new(FLASH_COOKIE_NAME, data);
+            
+            let mut flash_cookie = Cookie::new(FLASH_COOKIE_NAME, data);
+            flash_cookie.set_path("/");
+
             let response_future = response.and_then(move |mut res| {
                 res.add_cookie(&flash_cookie)
                     .map_err(|e| e.into())
@@ -272,6 +275,7 @@ impl<S> Middleware<S> for FlashMiddleware {
             // Delete cookie by setting an expiry date in the past
             let mut expired = Cookie::new(FLASH_COOKIE_NAME, "");
             expired.set_expires(EMPTY_TM);
+            expired.set_path("/");
             resp.add_cookie(&expired)?;
         }
         Ok(Response::Done(resp))


### PR DESCRIPTION
It is typically the case that one will want to read the flash message on the current redirect (next page load), regardless of whether the `FlashReponse` is redirecting to a different path base (e.g. from `/some/path` to `/other/path`).

Currently, the flash cookie will not be seen if the redirect has a different path base. This PR sets the cookie path to "/" so that flash cookies can be seen anywhere across the site.

This is how Rocket, for example, sets up flash cookies (https://api.rocket.rs/src/rocket/response/flash.rs.html#174).